### PR TITLE
カテゴリリストのアンカーサイズの変更

### DIFF
--- a/css/index/main.css
+++ b/css/index/main.css
@@ -101,10 +101,11 @@ html body header .header-top .header-top-content .header-top-content-item .heade
   box-shadow: 4px 4px 10px gray;
 }
 html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field .header-top-content-item-field-title {
+  box-sizing: border-box;
   font-size: 1.2rem;
   width: 100%;
   padding-left: 10px;
-  margin-bottom: 25px;
+  padding-bottom: 25px;
 }
 html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field ul {
   margin: 0px 40px 20px 40px;

--- a/css/index/main.css
+++ b/css/index/main.css
@@ -113,13 +113,19 @@ html body header .header-top .header-top-content .header-top-content-item .heade
   width: 150px;
 }
 html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field ul li {
-  text-align: center;
-  font-size: 1.1rem;
-  border-bottom: 1px solid black;
-  padding-top: 10px;
-  cursor: pointer;
+  margin-top: 10px;
 }
-html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field ul li:hover {
+html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field ul li a {
+  font-size: 1.1rem;
+  text-align: center;
+  border-bottom: 1px solid black;
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  margin: 0;
+}
+html body header .header-top .header-top-content .header-top-content-item .header-top-content-item-field ul li a:hover {
   border-bottom: 1px solid orange;
   transition: 0.25s;
 }

--- a/css/index/main.scss
+++ b/css/index/main.scss
@@ -94,10 +94,11 @@ html {
                             background-color: white;
                             box-shadow: 4px 4px 10px gray;
                             .header-top-content-item-field-title {
+                                box-sizing: border-box;
                                 font-size: 1.2rem;
                                 width: 100%;
                                 padding-left: 10px;
-                                margin-bottom: 25px;
+                                padding-bottom: 25px;
                             }
                             ul {
                                 margin: 0px 40px 20px 40px;

--- a/css/index/main.scss
+++ b/css/index/main.scss
@@ -105,14 +105,20 @@ html {
                                 list-style: none;
                                 width: 150px;
                                 li {
-                                    text-align: center;
-                                    font-size: 1.1rem;
-                                    border-bottom: 1px solid black;
-                                    padding-top: 10px;
-                                    cursor: pointer;
-                                    &:hover {
-                                        border-bottom: 1px solid orange;
-                                        transition: .25s;
+                                    margin-top: 10px;
+                                    a {
+                                        font-size: 1.1rem;
+                                        text-align: center;
+                                        border-bottom: 1px solid black;
+                                        display: inline-block;
+                                        width: 100%;
+                                        height: 100%;
+                                        cursor: pointer;
+                                        margin: 0;
+                                        &:hover {
+                                            border-bottom: 1px solid orange;
+                                            transition: .25s;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
ヘッダー内のカテゴリーリストのアンカーサイズの変更により、文字上でのクリックでしか他ページに飛べなかったのが、左右の余白でも他ページに飛べれるように変更

また、ヘッダー内のカテゴリホバー時の見出しの余白のサイズ関連の変更をしたが、こちらは見た目上での変化は見れない